### PR TITLE
New job handling in RunKit + improved env.sh

### DIFF
--- a/NanoProd/crab/crab_test.yaml
+++ b/NanoProd/crab/crab_test.yaml
@@ -4,7 +4,10 @@ config:
     sampleType: mc
     storeFailed: true
     maxEvents: 100
+    maxFiles: 1
+    copyInputsToLocal: false
     customiseCmds: "process.Timing = cms.Service('Timing', summaryOnly=cms.untracked.bool(True)); process.SimpleMemoryCheck = cms.Service('SimpleMemoryCheck', jobReportOutputOnly=cms.untracked.bool(True)); process.CPU = cms.Service('CPU')"
   dryrun: true
 
-TTTo2L2Nu: /TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1/MINIAODSIM
+# TTTo2L2Nu: /TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1/MINIAODSIM
+DYJetsToLL_M-50-madgraphMLM: /DYJetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM

--- a/NanoProd/crab/overseer_cfg.yaml
+++ b/NanoProd/crab/overseer_cfg.yaml
@@ -4,30 +4,31 @@ params:
   skimCfg: skim.yaml
   maxEvents: -1
 splitting: FileBased
-unitsPerJob: 4
-scriptExe: RunKit/nanoProdCrabJob.sh
+unitsPerJob: 8
+scriptExe: RunKit/crabJob.sh
 outputFiles:
   - nano.root
 filesToTransfer:
-  - RunKit/nanoProdCrabJob.sh
-  - RunKit/nanoProdCrabJob.py
+  - RunKit/crabJob.sh
+  - RunKit/crabJob.py
+  - RunKit/crabJob_nanoProd.py
   - RunKit/skim_tree.py
   - RunKit/sh_tools.py
   - NanoProd/data/skim.yaml
 site: T2_CH_CERN
-crabOutput: /store/group/phys_tau/kandroso/DeepTau_v2p5_UL18_prod
-finalOutput: /eos/cms/store/group/phys_tau/kandroso/DeepTau_v2p5_UL18
-localCrabOutput: /eos/cms/store/group/phys_tau/kandroso/DeepTau_v2p5_UL18_prod
+crabOutput: /store/group/phys_tau/kandroso/DeepTau_v2p5_UL17_prod
+finalOutput: /eos/cms/store/group/phys_tau/kandroso/DeepTau_v2p5_UL17
+localCrabOutput: /eos/cms/store/group/phys_tau/kandroso/DeepTau_v2p5_UL17_prod
 maxMemory: 2500
 numCores: 1
 inputDBS: global
 allowNonValid: False
 dryrun: False
-maxResubmitCount: 2
+maxResubmitCount: 0
 maxRecoveryCount: 2
 updateInterval: 60
 postProcessing:
-  lawTask: CrabNanoProdTaskPostProcess
+  lawTask: ProdTask
   workflow: htcondor
   bootstrap: bootstrap.sh
 postProcessingDoneFlag: post_processing_done.txt

--- a/NanoProd/crab/overseer_cfg.yaml
+++ b/NanoProd/crab/overseer_cfg.yaml
@@ -24,14 +24,12 @@ numCores: 1
 inputDBS: global
 allowNonValid: False
 dryrun: False
-maxResubmitCount: 0
-maxRecoveryCount: 2
+maxRecoveryCount: 3
 updateInterval: 60
-postProcessing:
+localProcessing:
   lawTask: ProdTask
   workflow: htcondor
   bootstrap: bootstrap.sh
-postProcessingDoneFlag: post_processing_done.txt
 #  requirements: ( (OpSysAndVer =?= "CentOS7") || (OpSysAndVer =?= "CentOS8") )
 targetOutputFileSize: 2048
 renewKerberosTicket: True

--- a/env.sh
+++ b/env.sh
@@ -97,8 +97,10 @@ action() {
   local default_cmssw_ver=CMSSW_12_4_8
   export DEFAULT_CMSSW_BASE="$ANALYSIS_PATH/soft/CentOS$os_version/$default_cmssw_ver"
 
-  autoload bashcompinit
-  bashcompinit
+  if [ ! -z $ZSH_VERSION ]; then
+    autoload bashcompinit
+    bashcompinit
+  fi
   source /cvmfs/sft.cern.ch/lcg/views/setupViews.sh LCG_102 x86_64-centos${os_version}-gcc11-opt
   source /afs/cern.ch/user/m/mrieger/public/law_sw/setup.sh
 

--- a/env.sh
+++ b/env.sh
@@ -1,82 +1,113 @@
 #!/usr/bin/env bash
 
 function run_cmd {
-    "$@"
-    RESULT=$?
-    if (( $RESULT != 0 )); then
-        echo "Error while running '$@'"
-        kill -INT $$
+  "$@"
+  RESULT=$?
+  if (( $RESULT != 0 )); then
+    echo "Error while running '$@'"
+    kill -INT $$
+  fi
+}
+
+do_install_cmssw() {
+  local this_file="$( [ ! -z "$ZSH_VERSION" ] && echo "${(%):-%x}" || echo "${BASH_SOURCE[0]}" )"
+  local this_dir="$( cd "$( dirname "$this_file" )" && pwd )"
+
+  export SCRAM_ARCH=$1
+  local CMSSW_VER=$2
+  local os_version=$3
+  if ! [ -f "$this_dir/soft/CentOS$os_version/$CMSSW_VER/.installed" ]; then
+    run_cmd mkdir -p "$this_dir/soft/CentOS$os_version"
+    run_cmd cd "$this_dir/soft/CentOS$os_version"
+    run_cmd source /cvmfs/cms.cern.ch/cmsset_default.sh
+    if [ -d $CMSSW_VER ]; then
+      echo "Removing incomplete $CMSSW_VER installation..."
+      run_cmd rm -rf $CMSSW_VER
     fi
+    echo "Creating $CMSSW_VER area for CentOS$os_version in $PWD ..."
+    run_cmd scramv1 project CMSSW $CMSSW_VER
+    run_cmd cd $CMSSW_VER/src
+    run_cmd eval `scramv1 runtime -sh`
+    run_cmd git-cms-init
+    run_cmd git clone ssh://git@gitlab.cern.ch:7999/akhukhun/roccor.git RoccoR
+    run_cmd git clone git@github.com:SVfit/ClassicSVfit.git TauAnalysis/ClassicSVfit -b fastMTT_19_02_2019
+    run_cmd git clone git@github.com:SVfit/SVfitTF.git TauAnalysis/SVfitTF
+    run_cmd git clone ssh://git@gitlab.cern.ch:7999/rgerosa/particlenetstudiesrun2.git ParticleNetStudiesRun2
+    run_cmd cd ParticleNetStudiesRun2
+    run_cmd git checkout 4521bb16157d632e8e519e2032dd42af9bdcaadd
+    run_cmd cd ..
+    #run_cmd mkdir -p $CMSSW_BASE/external/$SCRAM_ARCH/data/RecoBTag/Combined/data/
+    #run_cmd cp -r ParticleNetStudiesRun2/TrainingNtupleMakerAK4/data/ParticleNetAK4 $CMSSW_BASE/external/$SCRAM_ARCH/data/RecoBTag/Combined/data/
+    #run_cmd cp -r ParticleNetStudiesRun2/TrainingNtupleMakerAK8/data/ParticleNetAK8 $CMSSW_BASE/external/$SCRAM_ARCH/data/RecoBTag/Combined/data/
+    #run_cmd mkdir -p $CMSSW_BASE/external/$SCRAM_ARCH/data/RecoTauTag/data/TauES/
+    #run_cmd cp -r ParticleNetStudiesRun2/TrainingNtupleMakerAK4/data/TauES/* $CMSSW_BASE/external/$SCRAM_ARCH/data/RecoTauTag/data/TauES/
+    run_cmd git cms-addpkg RecoBTag/Combined
+    #run_cmd mkdir -p RecoBTag/Combined/data/
+    #run_cmd cp -r ParticleNetStudiesRun2/TrainingNtupleMakerAK4/data/ParticleNetAK4 RecoBTag/Combined/data
+    run_cmd mkdir -p RecoBTag/Combined/data/ParticleNetAK4/CHS/PNETUL
+    run_cmd cp -r ParticleNetStudiesRun2/TrainingNtupleMakerAK4/data/ParticleNetAK4/CHS/PNETUL/ClassRegQuantileNoJECLost RecoBTag/Combined/data/ParticleNetAK4/CHS/PNETUL/
+    #run_cmd cp -r ParticleNetStudiesRun2/TrainingNtupleMakerAK8/data/ParticleNetAK8 RecoBTag/Combined/data
+    #run_cmd git cms-addpkg RecoTauTag
+    #run_cmd mkdir -p RecoTauTag/data/TauES/
+    #run_cmd cp -r ParticleNetStudiesRun2/TrainingNtupleMakerAK4/data/TauES/* RecoTauTag/data/TauES/
+    run_cmd ln -s "$this_dir" NanoProd
+    run_cmd scram b -j8
+    run_cmd cd "$this_dir"
+    # run_cmd mkdir -p "$this_dir/soft/CentOS$os_version/bin"
+    # run_cmd ln -s $(which python3) "$this_dir/soft/CentOS$os_version/bin/python"
+    run_cmd touch "$this_dir/soft/CentOS$os_version/$CMSSW_VER/.installed"
+  fi
+}
+
+install_cmssw() {
+  local this_file="$( [ ! -z "$ZSH_VERSION" ] && echo "${(%):-%x}" || echo "${BASH_SOURCE[0]}" )"
+  local this_dir="$( cd "$( dirname "$this_file" )" && pwd )"
+  local scram_arch=$1
+  local cmssw_version=$2
+  local os_version=$3
+  if [[ $os_version < 8 ]] ; then
+    local env_cmd=cmssw-cc$os_version
+  else
+    local env_cmd=cmssw-el$os_version
+  fi
+  if ! [ -f "$this_dir/soft/CentOS$os_version/$CMSSW_VER/.installed" ]; then
+    run_cmd $env_cmd --command-to-run /usr/bin/env -i HOME=$HOME bash "$this_file" install_cmssw $scram_arch $cmssw_version $os_version
+  fi
 }
 
 action() {
-    # determine the directory of this file
-    local this_file="$( [ ! -z "$ZSH_VERSION" ] && echo "${(%):-%x}" || echo "${BASH_SOURCE[0]}" )"
-    local this_dir="$( cd "$( dirname "$this_file" )" && pwd )"
+  # determine the directory of this file
+  local this_file="$( [ ! -z "$ZSH_VERSION" ] && echo "${(%):-%x}" || echo "${BASH_SOURCE[0]}" )"
+  local this_dir="$( cd "$( dirname "$this_file" )" && pwd )"
 
-    export PYTHONPATH="$this_dir:$PYTHONPATH"
-    export LAW_HOME="$this_dir/.law"
-    export LAW_CONFIG_FILE="$this_dir/NanoProd/config/law.cfg"
+  export PYTHONPATH="$this_dir:$PYTHONPATH"
+  export LAW_HOME="$this_dir/.law"
+  export LAW_CONFIG_FILE="$this_dir/NanoProd/config/law.cfg"
 
-    export ANALYSIS_PATH="$this_dir"
-    export ANALYSIS_DATA_PATH="$ANALYSIS_PATH/data"
-    export X509_USER_PROXY="$ANALYSIS_DATA_PATH/voms.proxy"
+  export ANALYSIS_PATH="$this_dir"
+  export ANALYSIS_DATA_PATH="$ANALYSIS_PATH/data"
+  export X509_USER_PROXY="$ANALYSIS_DATA_PATH/voms.proxy"
 
-    run_cmd mkdir -p "$ANALYSIS_DATA_PATH"
-    # source /cvmfs/sft.cern.ch/lcg/views/setupViews.sh LCG_101 x86_64-centos7-gcc8-opt
-    # conda activate bbtt
+  run_cmd mkdir -p "$ANALYSIS_DATA_PATH"
 
-    local os_version=$(cat /etc/os-release | grep VERSION_ID | sed -E 's/VERSION_ID="([0-9]+)"/\1/')
-    if [ $os_version = "7" ]; then
-        export SCRAM_ARCH=slc7_amd64_gcc10
-    else
-        export SCRAM_ARCH=el8_amd64_gcc10
-    fi
-    CMSSW_VER=CMSSW_12_4_8
-    if ! [ -f "$this_dir/soft/CentOS$os_version/$CMSSW_VER/.installed" ]; then
-        run_cmd mkdir -p "$this_dir/soft/CentOS$os_version"
-        run_cmd cd "$this_dir/soft/CentOS$os_version"
-        if [ -d $CMSSW_VER ]; then
-            echo "Removing incomplete $CMSSW_VER installation..."
-            run_cmd rm -rf $CMSSW_VER
-            run_cmd rm -f "$this_dir/soft/CentOS$os_version/bin/python"
-        fi
-        echo "Creating $CMSSW_VER area for CentOS$os_version in $PWD ..."
-        run_cmd scramv1 project CMSSW $CMSSW_VER
-        run_cmd cd $CMSSW_VER/src
-        run_cmd eval `scramv1 runtime -sh`
-        run_cmd git-cms-init
-        run_cmd git clone ssh://git@gitlab.cern.ch:7999/akhukhun/roccor.git RoccoR
-        run_cmd git clone git@github.com:SVfit/ClassicSVfit.git TauAnalysis/ClassicSVfit -b fastMTT_19_02_2019
-        run_cmd git clone git@github.com:SVfit/SVfitTF.git TauAnalysis/SVfitTF
-        run_cmd git clone ssh://git@gitlab.cern.ch:7999/rgerosa/particlenetstudiesrun2.git ParticleNetStudiesRun2 -b cmssw_126X
-        #run_cmd mkdir -p $CMSSW_BASE/external/$SCRAM_ARCH/data/RecoBTag/Combined/data/
-        #run_cmd cp -r ParticleNetStudiesRun2/TrainingNtupleMakerAK4/data/ParticleNetAK4 $CMSSW_BASE/external/$SCRAM_ARCH/data/RecoBTag/Combined/data/
-        #run_cmd cp -r ParticleNetStudiesRun2/TrainingNtupleMakerAK8/data/ParticleNetAK8 $CMSSW_BASE/external/$SCRAM_ARCH/data/RecoBTag/Combined/data/
-        #run_cmd mkdir -p $CMSSW_BASE/external/$SCRAM_ARCH/data/RecoTauTag/data/TauES/
-        #run_cmd cp -r ParticleNetStudiesRun2/TrainingNtupleMakerAK4/data/TauES/* $CMSSW_BASE/external/$SCRAM_ARCH/data/RecoTauTag/data/TauES/
-        run_cmd git cms-addpkg RecoBTag/Combined
-        #run_cmd mkdir -p RecoBTag/Combined/data/
-        #run_cmd cp -r ParticleNetStudiesRun2/TrainingNtupleMakerAK4/data/ParticleNetAK4 RecoBTag/Combined/data
-        run_cmd mkdir -p RecoBTag/Combined/data/ParticleNetAK4/CHS/PNETUL
-        run_cmd cp -r ParticleNetStudiesRun2/TrainingNtupleMakerAK4/data/ParticleNetAK4/CHS/PNETUL/ClassRegQuantileNoJECLost RecoBTag/Combined/data/ParticleNetAK4/CHS/PNETUL/
-        #run_cmd cp -r ParticleNetStudiesRun2/TrainingNtupleMakerAK8/data/ParticleNetAK8 RecoBTag/Combined/data
-        #run_cmd git cms-addpkg RecoTauTag
-        #run_cmd mkdir -p RecoTauTag/data/TauES/
-        #run_cmd cp -r ParticleNetStudiesRun2/TrainingNtupleMakerAK4/data/TauES/* RecoTauTag/data/TauES/
-        run_cmd ln -s "$this_dir" NanoProd
-        run_cmd scram b -j8
-        run_cmd cd "$this_dir"
-        run_cmd mkdir -p "$this_dir/soft/CentOS$os_version/bin"
-        run_cmd ln -s $(which python3) "$this_dir/soft/CentOS$os_version/bin/python"
-        touch "$this_dir/soft/CentOS$os_version/$CMSSW_VER/.installed"
-    else
-        run_cmd cd "$this_dir/soft/CentOS$os_version/$CMSSW_VER/src"
-        run_cmd eval `scramv1 runtime -sh`
-        run_cmd cd "$this_dir"
-    fi
-    export PATH="$this_dir/soft/CentOS$os_version/bin:$PATH"
-    source /afs/cern.ch/user/m/mrieger/public/law_sw/setup.sh
-    source "$( law completion )"
+  run_cmd install_cmssw slc7_amd64_gcc10 CMSSW_12_4_8 7 nano_prod
+  run_cmd install_cmssw el8_amd64_gcc10 CMSSW_12_4_8 8 nano_prod
+
+  local os_version=$(cat /etc/os-release | grep VERSION_ID | sed -E 's/VERSION_ID="([0-9]+)"/\1/')
+  local default_cmssw_ver=CMSSW_12_4_8
+  export DEFAULT_CMSSW_BASE="$ANALYSIS_PATH/soft/CentOS$os_version/$default_cmssw_ver"
+
+  autoload bashcompinit
+  bashcompinit
+  source /cvmfs/sft.cern.ch/lcg/views/setupViews.sh LCG_102 x86_64-centos${os_version}-gcc11-opt
+  source /afs/cern.ch/user/m/mrieger/public/law_sw/setup.sh
+
+  source "$( law completion )" ""
+  alias cmsEnv="env -i HOME=$HOME ANALYSIS_PATH=$ANALYSIS_PATH X509_USER_PROXY=$X509_USER_PROXY DEFAULT_CMSSW_BASE=$DEFAULT_CMSSW_BASE $ANALYSIS_PATH/RunKit/cmsEnv.sh"
 }
-action
+
+if [ "X$1" = "Xinstall_cmssw" ]; then
+  do_install_cmssw "${@:2}"
+else
+  action "$@"
+fi


### PR DESCRIPTION
- New job handling in RunKit - see https://github.com/kandrosov/RunKit/pull/3 for details
- improved environment setup:
  - using LCG environment instead of CMSSW
  - to run in CMSSW use `cmsEnv ....`
  - create areas for CentOS7 & 8 during the first call of env.sh independently on the host OS
  - requiring an exact commit for the PNet package to improve the reproducibility of the setup