### PR TITLE
Add 'tmp_area' config key

### DIFF
--- a/NanoProd/crab/overseer_cfg.yaml
+++ b/NanoProd/crab/overseer_cfg.yaml
@@ -19,6 +19,7 @@ filesToTransfer:
   - NanoProd/config/skim_htt.yaml
   - NanoProd/python/customize.py
 site: T2_CH_CERN
+tmp_area: TMPDIR
 crabOutput: /store/group/phys_tau/irandreo/Run3_22_prod
 finalOutput: /eos/cms/store/group/phys_tau/irandreo/Run3_22
 localCrabOutput: /eos/cms/store/group/phys_tau/irandreo/Run3_22_prod


### PR DESCRIPTION
From the merged PR https://github.com/kandrosov/RunKit/pull/7 in RunKit, the overseer config now requires an additional entry `tmp_area`. Default value `TMPDIR` will use the location set in the environmental variable of the same name. This is only used to copy crab output from a non-local storage site.