### PR TITLE
PR: Switching to CMSSW_14_0_5

### DIFF
--- a/NanoProd/config/skim_htt.yaml
+++ b/NanoProd/config/skim_htt.yaml
@@ -126,7 +126,7 @@ selection: "
   int n_electrons = Electron_pt[ele_sel].size();
   int n_muons = Muon_pt[muon_sel].size();
   int n_taus = Tau_pt[tau_sel].size();
-  int n_met = std::max({MET_pt, DeepMETResolutionTune_pt, DeepMETResponseTune_pt, PuppiMET_pt}) > 100;
+  int n_met = std::max({PFMET_pt, DeepMETResolutionTune_pt, DeepMETResponseTune_pt, PuppiMET_pt}) > 100;
 
   return n_electrons + n_muons + n_taus + n_met >= 2;
   "

--- a/env.sh
+++ b/env.sh
@@ -93,7 +93,7 @@ action() {
   local os_prefix=$(get_os_prefix $os_version)
   local node_os=$os_prefix$os_version
 
-  local default_cmssw_ver=CMSSW_14_0_1
+  local default_cmssw_ver=CMSSW_14_0_5
   #local target_os_version=7
   local target_os_version=8
   #local target_os_version=9


### PR DESCRIPTION
Switching the CMSSW version from 14_0_1 to CMSSW_14_0_5 to be able to use Puppi MET covariance