### PR TITLE
Add TauSpinner weight table from HTT samples

### DIFF
--- a/NanoProd/plugins/BuildFile.xml
+++ b/NanoProd/plugins/BuildFile.xml
@@ -4,3 +4,4 @@
 <use name="RecoVertex/AdaptiveVertexFit"/>
 <use name="RecoVertex/VertexPrimitives"/>
 <use name="TrackingTools/TransientTrack"/>
+<use name="tauolapp"/>

--- a/NanoProd/plugins/TauSpinnerTableProducer.cc
+++ b/NanoProd/plugins/TauSpinnerTableProducer.cc
@@ -90,7 +90,7 @@ TauSpinnerTableProducer::TauSpinnerTableProducer(const edm::ParameterSet &config
       nonSM2_(0),
       nonSMN_(0),
       cmsE_(config.getParameter<double>("cmsE")),  //cms energy in GeV, 13000.0
-      default_weight_(0)  //default weight stored in case of presence of a tau decay unsupported by TauSpinner
+      default_weight_(1)  //default weight stored in case of presence of a tau decay unsupported by TauSpinner
 {
   printModuleInfo(config);
 

--- a/NanoProd/plugins/TauSpinnerTableProducer.cc
+++ b/NanoProd/plugins/TauSpinnerTableProducer.cc
@@ -6,13 +6,6 @@
                   update, M. Bluj (NCBJ)
 */
 
-#include <memory>
-#include <vector>
-#include <string>
-
-#include "boost/functional/hash.hpp"
-#include "boost/format.hpp"
-
 #include "FWCore/Framework/interface/one/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -27,31 +20,28 @@
 #include "TauSpinner/tau_reweight_lib.h"
 
 namespace {
-  std::set<int> tauProdsIds{22, 111, 211, 321, 130, 310, 11, 12, 13, 14, 16};
-}
+  //const std::set<int> tauProdsIds{22, 111, 211, 221, 223, 321, 130, 310, 311, 321, 323, 11, 12, 13, 14, 16};//FIXME
+  const std::set<int> tauProdsIds{22, 111, 211, 321, 130, 310, 11, 12, 13, 14, 16};
+}  // namespace
 
 class TauSpinnerTableProducer : public edm::one::EDProducer<edm::one::SharedResources> {
 public:
   explicit TauSpinnerTableProducer(const edm::ParameterSet &);
-  ~TauSpinnerTableProducer() override{};
 
   void produce(edm::Event &, const edm::EventSetup &) final;
-  void beginJob() final { initialize(); }
-  void endJob() final {}
+  void beginJob() final;
 
 private:
-  void initialize();
-
   void getBosons(edm::RefVector<edm::View<reco::GenParticle>> &bosons, const edm::View<reco::GenParticle> &parts) const;
-  reco::GenParticleRef getLastCopy(const reco::GenParticleRef &part) const;
-  void getTaus(reco::GenParticleRefVector &taus, const reco::GenParticle &boson) const;
-  void getTauDaughters(reco::GenParticleRefVector &tau_daughters, unsigned &type, const reco::GenParticle &tau) const;
+  static reco::GenParticleRef getLastCopy(const reco::GenParticleRef &part);
+  static void getTaus(reco::GenParticleRefVector &taus, const reco::GenParticle &boson);
+  static void getTauDaughters(reco::GenParticleRefVector &tau_daughters, const reco::GenParticle &tau);
   TauSpinner::SimpleParticle convertToSimplePart(const reco::GenParticle &input_part) const {
     return TauSpinner::SimpleParticle(
         input_part.px(), input_part.py(), input_part.pz(), input_part.energy(), input_part.pdgId());
   }
 
-  std::vector<std::pair<std::string, double>> nameAndValue(const std::vector<double> &val_vec) const {
+  static std::vector<std::pair<std::string, double>> nameAndValue(const std::vector<double> &val_vec) {
     std::vector<std::pair<std::string, double>> out;
     for (auto val : val_vec) {
       std::string name = std::to_string(val);
@@ -69,35 +59,33 @@ private:
   }
 
   void printModuleInfo(edm::ParameterSet const &config) const {
-    std::string header = (boost::format("%-39s%39s") % config.getParameter<std::string>("@module_type") %
-                          config.getParameter<std::string>("@module_label"))
-                             .str();
     std::cout << std::string(78, '-') << "\n";
-    std::cout << header << "\n";
-    // std::cout << "Produces: " << flow << "\n";
-    std::cout << boost::format("%-15s : %-60s\n") % "Input" % config.getParameter<edm::InputTag>("input").encode();
-    std::cout << boost::format("%-15s : %-60s\n") % "Branch" % config.getParameter<std::string>("branch");
+    std::cout << config.getParameter<std::string>("@module_type") << '/'
+              << config.getParameter<std::string>("@module_label") << "\n";
+    std::cout << "Input: " << config.getParameter<edm::InputTag>("input").encode() << '\n';
+    std::cout << "Branch: " << config.getParameter<std::string>("branch") << '\n';
     std::string thetaStr;
     for (const auto &theta : theta_vec_)
       thetaStr += theta.first + ",";
-    std::cout << boost::format("%-15s : %-60s\n") % "Theta" % thetaStr;
+    std::cout << "Theta: " << thetaStr << std::endl;
   }
 
-  edm::EDGetTokenT<edm::View<reco::GenParticle>> genPartsToken_;
-  std::string branch_;
-  std::vector<std::pair<std::string, double>> theta_vec_;
-  int bosonPdgId_;
-  std::string tauSpinnerPDF_;
-  bool ipp_;
-  int ipol_;
-  int nonSM2_;
-  int nonSMN_;
-  double cmsE_;
+  const edm::EDGetTokenT<edm::View<reco::GenParticle>> genPartsToken_;
+  const std::string branch_;
+  const std::vector<std::pair<std::string, double>> theta_vec_;
+  const int bosonPdgId_;
+  const std::string tauSpinnerPDF_;
+  const bool ipp_;
+  const int ipol_;
+  const int nonSM2_;
+  const int nonSMN_;
+  const double cmsE_;
 };
 
 TauSpinnerTableProducer::TauSpinnerTableProducer(const edm::ParameterSet &config)
     : genPartsToken_(consumes(config.getParameter<edm::InputTag>("input"))),
       branch_(config.getParameter<std::string>("branch")),
+      theta_vec_(nameAndValue(config.getParameter<std::vector<double>>("theta"))),
       bosonPdgId_(25),                                             //Higgs, to be configurable?
       tauSpinnerPDF_(config.getParameter<std::string>("pdfSet")),  //"NNPDF30_nlo_as_0118"
       ipp_(true),                                                  //pp collisions
@@ -106,8 +94,6 @@ TauSpinnerTableProducer::TauSpinnerTableProducer(const edm::ParameterSet &config
       nonSMN_(0),
       cmsE_(config.getParameter<double>("cmsE"))  //cms energy in GeV, 13000.0
 {
-  theta_vec_ = nameAndValue(config.getParameter<std::vector<double>>("theta"));
-
   printModuleInfo(config);
 
   //state that we use tauola/tauspinner resource
@@ -119,7 +105,7 @@ TauSpinnerTableProducer::TauSpinnerTableProducer(const edm::ParameterSet &config
 void TauSpinnerTableProducer::getBosons(edm::RefVector<edm::View<reco::GenParticle>> &bosons,
                                         const edm::View<reco::GenParticle> &parts) const {
   unsigned idx = 0;
-  for (auto part : parts) {
+  for (const auto &part : parts) {
     if (std::abs(part.pdgId()) == bosonPdgId_ && part.isLastCopy()) {
       edm::Ref<edm::View<reco::GenParticle>> partRef(&parts, idx);
       bosons.push_back(partRef);
@@ -128,43 +114,35 @@ void TauSpinnerTableProducer::getBosons(edm::RefVector<edm::View<reco::GenPartic
   }
 }
 
-reco::GenParticleRef TauSpinnerTableProducer::getLastCopy(const reco::GenParticleRef &part) const {
-  reco::GenParticleRef last_copy(part);
-  if (part->statusFlags().isLastCopy() && part->statusFlags().fromHardProcess())
-    return last_copy;
+reco::GenParticleRef TauSpinnerTableProducer::getLastCopy(const reco::GenParticleRef &part) {
+  if (part->statusFlags().isLastCopy())
+    return part;
   for (const auto &daughter : part->daughterRefVector()) {
-    if (daughter->pdgId() == part->pdgId()) {
-      last_copy = getLastCopy(daughter);
+    if (daughter->pdgId() == part->pdgId() && daughter->statusFlags().fromHardProcess()) {
+      return getLastCopy(daughter);
     }
   }
-  return last_copy;
+  throw std::runtime_error("getLastCopy: no last copy found");
 }
 
-void TauSpinnerTableProducer::getTaus(reco::GenParticleRefVector &taus, const reco::GenParticle &boson) const {
-  for (auto daughterRef : boson.daughterRefVector()) {
-    if (std::abs(daughterRef->pdgId()) != 15)
-      continue;
-    taus.push_back(getLastCopy(daughterRef));
+void TauSpinnerTableProducer::getTaus(reco::GenParticleRefVector &taus, const reco::GenParticle &boson) {
+  for (const auto &daughterRef : boson.daughterRefVector()) {
+    if (std::abs(daughterRef->pdgId()) == 15)
+      taus.push_back(getLastCopy(daughterRef));
   }
 }
 
-void TauSpinnerTableProducer::getTauDaughters(reco::GenParticleRefVector &tau_daughters,
-                                              unsigned &type,
-                                              const reco::GenParticle &tau) const {
+void TauSpinnerTableProducer::getTauDaughters(reco::GenParticleRefVector &tau_daughters, const reco::GenParticle &tau) {
   for (auto daughterRef : tau.daughterRefVector()) {
-    int daughter_pdgid = std::abs(daughterRef->pdgId());
-    if (tauProdsIds.find(daughter_pdgid) != tauProdsIds.end()) {
-      if (daughter_pdgid == 11)
-        type = 1;
-      if (daughter_pdgid == 13)
-        type = 2;
+    if (tauProdsIds.find(std::abs(daughterRef->pdgId())) == tauProdsIds.end())
+      getTauDaughters(tau_daughters, *daughterRef);
+    //throw std::runtime_error("Unknown tau decay product, pdgId = " + std::to_string(daughterRef->pdgId()));//FIXME
+    else
       tau_daughters.push_back(daughterRef);
-    } else
-      getTauDaughters(tau_daughters, type, *daughterRef);
   }
 }
 
-void TauSpinnerTableProducer::initialize() {
+void TauSpinnerTableProducer::beginJob() {
   // Initialize TauSpinner
   Tauolapp::Tauola::setNewCurrents(0);
   Tauolapp::Tauola::initialize();
@@ -188,7 +166,7 @@ void TauSpinnerTableProducer::produce(edm::Event &event, const edm::EventSetup &
     return;
   }
 
-  // Search dor taus from boson decay
+  // Search for taus from boson decay
   reco::GenParticleRefVector taus;
   getTaus(taus, *bosons[0]);
   if (taus.size() != 2) {  //boson does not decay to tau pair, produce empty table (expected for non HTT sample)
@@ -196,45 +174,38 @@ void TauSpinnerTableProducer::produce(edm::Event &event, const edm::EventSetup &
     return;
   }
 
-  // Tau daughters from boson decay
-  reco::GenParticleRefVector tau1_daughters;
-  reco::GenParticleRefVector tau2_daughters;
-  unsigned type1 = 0;
-  unsigned type2 = 0;
-  getTauDaughters(tau1_daughters, type1, *taus[0]);
-  getTauDaughters(tau2_daughters, type2, *taus[1]);
-
-  //convert particles to TauSpinner format
+  // Get tau daughters and convert all particles to TauSpinner format
   TauSpinner::SimpleParticle simple_boson = convertToSimplePart(*bosons[0]);
-  TauSpinner::SimpleParticle simple_tau1 = convertToSimplePart(*taus[0]);
-  TauSpinner::SimpleParticle simple_tau2 = convertToSimplePart(*taus[1]);
-  std::vector<TauSpinner::SimpleParticle> simple_tau1_daughters;
-  std::vector<TauSpinner::SimpleParticle> simple_tau2_daughters;
-  for (auto daughterRef : tau1_daughters)
-    simple_tau1_daughters.push_back(convertToSimplePart(*daughterRef));
-  for (auto daughterRef : tau2_daughters)
-    simple_tau2_daughters.push_back(convertToSimplePart(*daughterRef));
+  std::array<TauSpinner::SimpleParticle, 2> simple_taus;
+  std::array<std::vector<TauSpinner::SimpleParticle>, 2> simple_tau_daughters;
+  for (size_t tau_idx = 0; tau_idx < 2; ++tau_idx) {
+    simple_taus[tau_idx] = convertToSimplePart(*taus[tau_idx]);
+    reco::GenParticleRefVector tau_daughters;
+    getTauDaughters(tau_daughters, *taus[tau_idx]);
+    for (const auto &daughterRef : tau_daughters)
+      simple_tau_daughters[tau_idx].push_back(convertToSimplePart(*daughterRef));
+  }
 
   // Compute TauSpinner weights and fill table
-  double weight = 0;
+  std::array<double, 2> weights;
   for (const auto &theta : theta_vec_) {
     // Can make this more general by having boson pdgid as input or have option for set boson type
     TauSpinner::setHiggsParametersTR(-cos(2 * M_PI * theta.second),
                                      cos(2 * M_PI * theta.second),
                                      -sin(2 * M_PI * theta.second),
                                      -sin(2 * M_PI * theta.second));
-    Tauolapp::Tauola::setNewCurrents(0);
-    weight = TauSpinner::calculateWeightFromParticlesH(
-        simple_boson, simple_tau1, simple_tau2, simple_tau1_daughters, simple_tau2_daughters);
+    for (size_t i = 0; i < weights.size(); ++i) {
+      Tauolapp::Tauola::setNewCurrents(i);
+      weights[i] = TauSpinner::calculateWeightFromParticlesH(
+          simple_boson, simple_taus[0], simple_taus[1], simple_tau_daughters[0], simple_tau_daughters[1]);
+    }
+    // Nominal weights for setNewCurrents(0)
     wtTable->addColumnValue<double>(
-        "weight_cp_" + theta.first, weight, "TauSpinner weight for theta_CP=" + theta.first);
-    // also add weights for alternative hadronic currents (can be used for uncertainty estimates)
-    Tauolapp::Tauola::setNewCurrents(1);
-    weight = TauSpinner::calculateWeightFromParticlesH(
-        simple_boson, simple_tau1, simple_tau2, simple_tau1_daughters, simple_tau2_daughters);
+        "weight_cp_" + theta.first, weights[0], "TauSpinner weight for theta_CP=" + theta.first);
+    // Weights for alternative hadronic currents (can be used for uncertainty estimates)
     wtTable->addColumnValue<double>(
         "weight_cp_" + theta.first + "_alt",
-        weight,
+        weights[1],
         "TauSpinner weight for theta_CP=" + theta.first + " (alternative hadronic currents)");
   }
 

--- a/NanoProd/plugins/TauSpinnerTableProducer.cc
+++ b/NanoProd/plugins/TauSpinnerTableProducer.cc
@@ -1,0 +1,246 @@
+/**\class TauSpinnerTableProducer
+
+ Description: Produces FlatTable with TauSpinner weights for H->tau,tau events
+
+ Original Author: D.  Winterbottom (IC)
+                  update, M. Bluj (NCBJ)
+*/
+
+#include <memory>
+#include <vector>
+#include <string>
+
+#include "boost/functional/hash.hpp"
+#include "boost/format.hpp"
+
+#include "FWCore/Framework/interface/one/EDProducer.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Concurrency/interface/SharedResourceNames.h"
+#include "DataFormats/Common/interface/View.h"
+#include "DataFormats/HepMCCandidate/interface/GenParticle.h"
+#include "DataFormats/NanoAOD/interface/FlatTable.h"
+
+#include "Tauola/Tauola.h"
+#include "TauSpinner/SimpleParticle.h"
+#include "TauSpinner/tau_reweight_lib.h"
+
+namespace {
+  std::set<int> tauProdsIds{22, 111, 211, 321, 130, 310, 11, 12, 13, 14, 16};
+}
+
+class TauSpinnerTableProducer : public edm::one::EDProducer<edm::one::SharedResources> {
+public:
+  explicit TauSpinnerTableProducer(const edm::ParameterSet &);
+  ~TauSpinnerTableProducer() override{};
+
+  void produce(edm::Event &, const edm::EventSetup &) final;
+  void beginJob() final { initialize(); }
+  void endJob() final {}
+
+private:
+  void initialize();
+
+  reco::GenParticle getBoson(const edm::View<reco::GenParticle> &parts, bool &foundBoson) const;
+  reco::GenParticleRef getLastCopy(const reco::GenParticleRef &part) const;
+  void getTaus(reco::GenParticleRefVector &taus, const reco::GenParticle &boson) const;
+  void getTauDaughters(reco::GenParticleRefVector &tau_daughters, unsigned &type, const reco::GenParticle &tau) const;
+  TauSpinner::SimpleParticle convertToSimplePart(const reco::GenParticle &input_part) const {
+    return TauSpinner::SimpleParticle(
+        input_part.px(), input_part.py(), input_part.pz(), input_part.energy(), input_part.pdgId());
+  }
+
+  std::vector<std::pair<std::string, double>> nameAndValue(const std::vector<double> &val_vec) const {
+    std::vector<std::pair<std::string, double>> out;
+    for (auto val : val_vec) {
+      std::string name = std::to_string(val);
+      name.erase(name.find_last_not_of('0') + 1, std::string::npos);
+      name.erase(name.find_last_not_of('.') + 1, std::string::npos);
+      size_t pos = name.find(".");
+      if (pos != std::string::npos)
+        name.replace(pos, 1, "p");
+      pos = name.find("-");
+      if (pos != std::string::npos)
+        name.replace(pos, 1, "minus");
+      out.push_back(std::make_pair(name, val));
+    }
+    return out;
+  }
+
+  void printModuleInfo(edm::ParameterSet const &config) const {
+    std::string header = (boost::format("%-39s%39s") % config.getParameter<std::string>("@module_type") %
+                          config.getParameter<std::string>("@module_label"))
+                             .str();
+    std::cout << std::string(78, '-') << "\n";
+    std::cout << header << "\n";
+    // std::cout << "Produces: " << flow << "\n";
+    std::cout << boost::format("%-15s : %-60s\n") % "Input" % config.getParameter<edm::InputTag>("input").encode();
+    std::cout << boost::format("%-15s : %-60s\n") % "Branch" % config.getParameter<std::string>("branch");
+    std::string thetaStr;
+    for (const auto &theta : theta_vec_)
+      thetaStr += theta.first + ",";
+    std::cout << boost::format("%-15s : %-60s\n") % "Theta" % thetaStr;
+  }
+
+  edm::EDGetTokenT<edm::View<reco::GenParticle>> genPartsToken_;
+  std::string branch_;
+  std::vector<std::pair<std::string, double>> theta_vec_;
+  int bosonPdgId_;
+  std::string tauSpinnerPDF_;
+  bool ipp_;
+  int ipol_;
+  int nonSM2_;
+  int nonSMN_;
+  double cmsE_;
+};
+
+TauSpinnerTableProducer::TauSpinnerTableProducer(const edm::ParameterSet &config)
+    : genPartsToken_(consumes(config.getParameter<edm::InputTag>("input"))),
+      branch_(config.getParameter<std::string>("branch")),
+      bosonPdgId_(25),                                             //Higgs, to be configurable?
+      tauSpinnerPDF_(config.getParameter<std::string>("pdfSet")),  //"NNPDF30_nlo_as_0118"
+      ipp_(true),                                                  //pp collisions
+      ipol_(0),
+      nonSM2_(0),
+      nonSMN_(0),
+      cmsE_(config.getParameter<double>("cmsE"))  //cms energy in GeV, 13000.0
+{
+  theta_vec_ = nameAndValue(config.getParameter<std::vector<double>>("theta"));
+
+  printModuleInfo(config);
+
+  //state that we use tauola/tauspinner resource
+  usesResource(edm::SharedResourceNames::kTauola);
+
+  produces<nanoaod::FlatTable>();
+}
+
+reco::GenParticle TauSpinnerTableProducer::getBoson(const edm::View<reco::GenParticle> &parts, bool &foundBoson) const {
+  reco::GenParticle boson;
+  foundBoson = false;
+  for (auto part : parts) {
+    if (std::abs(part.pdgId()) == bosonPdgId_ && part.isLastCopy()) {
+      boson = part;
+      foundBoson = true;
+      break;
+    }
+  }
+  return boson;
+}
+
+reco::GenParticleRef TauSpinnerTableProducer::getLastCopy(const reco::GenParticleRef &part) const {
+  reco::GenParticleRef last_copy(part);
+  if (part->statusFlags().isLastCopy())
+    return last_copy;
+  for (const auto &daughter : part->daughterRefVector()) {
+    if (daughter->pdgId() == part->pdgId()) {
+      last_copy = getLastCopy(daughter);
+    }
+  }
+  return last_copy;
+}
+
+void TauSpinnerTableProducer::getTaus(reco::GenParticleRefVector &taus, const reco::GenParticle &boson) const {
+  for (auto daughterRef : boson.daughterRefVector()) {
+    if (std::abs(daughterRef->pdgId()) != 15)
+      continue;
+    taus.push_back(getLastCopy(daughterRef));
+  }
+}
+
+void TauSpinnerTableProducer::getTauDaughters(reco::GenParticleRefVector &tau_daughters,
+                                              unsigned &type,
+                                              const reco::GenParticle &tau) const {
+  for (auto daughterRef : tau.daughterRefVector()) {
+    int daughter_pdgid = std::abs(daughterRef->pdgId());
+    if (tauProdsIds.find(daughter_pdgid) != tauProdsIds.end()) {
+      if (daughter_pdgid == 11)
+        type = 1;
+      if (daughter_pdgid == 13)
+        type = 2;
+      tau_daughters.push_back(daughterRef);
+    } else
+      getTauDaughters(tau_daughters, type, *daughterRef);
+  }
+}
+
+void TauSpinnerTableProducer::initialize() {
+  // Initialize TauSpinner
+  Tauolapp::Tauola::setNewCurrents(0);
+  Tauolapp::Tauola::initialize();
+  LHAPDF::initPDFSetByName(tauSpinnerPDF_);
+  TauSpinner::initialize_spinner(ipp_, ipol_, nonSM2_, nonSMN_, cmsE_);
+}
+
+void TauSpinnerTableProducer::produce(edm::Event &event, const edm::EventSetup &setup) {
+  // Input gen-particles collection
+  auto const &genParts = event.get(genPartsToken_);
+
+  // Output table
+  auto wtTable = std::make_unique<nanoaod::FlatTable>(1, branch_, true);
+  wtTable->setDoc("TauSpinner weights");
+
+  // Search for boson
+  bool foundBoson = false;
+  reco::GenParticle boson = getBoson(genParts, foundBoson);
+  if (!foundBoson) {  //boson not found, produce empty table (expected for non HTT sample)
+    event.put(std::move(wtTable));
+    return;
+  }
+
+  // Search dor taus from boson decay
+  reco::GenParticleRefVector taus;
+  getTaus(taus, boson);
+  if (taus.size() != 2) {  //boson does not decay to tau pair, produce empty table (expected for non HTT sample)
+    event.put(std::move(wtTable));
+    return;
+  }
+
+  // Tau daughters from boson decay
+  reco::GenParticleRefVector tau1_daughters;
+  reco::GenParticleRefVector tau2_daughters;
+  unsigned type1 = 0;
+  unsigned type2 = 0;
+  getTauDaughters(tau1_daughters, type1, *taus[0]);
+  getTauDaughters(tau2_daughters, type2, *taus[1]);
+
+  //convert particles to TauSpinner format
+  TauSpinner::SimpleParticle simple_boson = convertToSimplePart(boson);
+  TauSpinner::SimpleParticle simple_tau1 = convertToSimplePart(*taus[0]);
+  TauSpinner::SimpleParticle simple_tau2 = convertToSimplePart(*taus[1]);
+  std::vector<TauSpinner::SimpleParticle> simple_tau1_daughters;
+  std::vector<TauSpinner::SimpleParticle> simple_tau2_daughters;
+  for (auto daughterRef : tau1_daughters)
+    simple_tau1_daughters.push_back(convertToSimplePart(*daughterRef));
+  for (auto daughterRef : tau2_daughters)
+    simple_tau2_daughters.push_back(convertToSimplePart(*daughterRef));
+
+  // Compute TauSpinner weights and fill table
+  double weight = 0;
+  for (const auto &theta : theta_vec_) {
+    // Can make this more general by having boson pdgid as input or have option for set boson type
+    TauSpinner::setHiggsParametersTR(-cos(2 * M_PI * theta.second),
+                                     cos(2 * M_PI * theta.second),
+                                     -sin(2 * M_PI * theta.second),
+                                     -sin(2 * M_PI * theta.second));
+    Tauolapp::Tauola::setNewCurrents(0);
+    weight = TauSpinner::calculateWeightFromParticlesH(
+        simple_boson, simple_tau1, simple_tau2, simple_tau1_daughters, simple_tau2_daughters);
+    wtTable->addColumnValue<double>(
+        "weight_cp_" + theta.first, weight, "TauSpinner weight for theta_CP=" + theta.first);
+    // also add weights for alternative hadronic currents (can be used for uncertainty estimates)
+    Tauolapp::Tauola::setNewCurrents(1);
+    weight = TauSpinner::calculateWeightFromParticlesH(
+        simple_boson, simple_tau1, simple_tau2, simple_tau1_daughters, simple_tau2_daughters);
+    wtTable->addColumnValue<double>(
+        "weight_cp_" + theta.first + "_alt",
+        weight,
+        "TauSpinner weight for theta_CP=" + theta.first + " (alternative hadronic currents)");
+  }
+
+  event.put(std::move(wtTable));
+}
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(TauSpinnerTableProducer);

--- a/NanoProd/python/customize.py
+++ b/NanoProd/python/customize.py
@@ -91,14 +91,14 @@ def addSpinnerWeights(process):
     "TauSpinnerTableProducer",
     branch   = cms.string("TauSpinner"),
     input    = cms.InputTag("prunedGenParticles"),
-    #theta    = cms.string("0,0.25,0.5,-0.25,0.375"),
     theta    = cms.vdouble(0,0.25,0.5,-0.25,0.375),
-    pdfSet   = cms.string("NNPDF30_nlo_as_0118"),
+    pdfSet   = cms.string("NNPDF31_nnlo_hessian_pdfas"),
     cmsE     = era_dependent_settings.cmsE #center of mass energy in GeV
   )
   process.globalTablesMCTask.add(process.tauSpinnerWeightTable)
 
   return process
+
 
 def customize(process):
   #customize printout frequency

--- a/NanoProd/python/customize.py
+++ b/NanoProd/python/customize.py
@@ -1,6 +1,13 @@
 import FWCore.ParameterSet.Config as cms
 from PhysicsTools.NanoAOD.common_cff import Var, CandVars
 from RecoTauTag.RecoTau.tauIdWPsDefs import WORKING_POINTS_v2p5
+from PhysicsTools.NanoAOD.nano_eras_cff import *
+
+# settings which can depend on (nanoAOD) era
+era_dependent_settings = cms.PSet(
+  cmsE = cms.double(13600.0), #center of mass energy in GeV (Run3 default)
+)
+(~run3_common).toModify(era_dependent_settings, cmsE = 13000.0)
 
 def customizeGenParticles(process):
   def pdgOR(pdgs):
@@ -79,6 +86,20 @@ def customizePV(process):
 
   return process
 
+def addSpinnerWeights(process):
+  process.tauSpinnerWeightTable = cms.EDProducer(
+    "TauSpinnerTableProducer",
+    branch   = cms.string("TauSpinner"),
+    input    = cms.InputTag("prunedGenParticles"),
+    #theta    = cms.string("0,0.25,0.5,-0.25,0.375"),
+    theta    = cms.vdouble(0,0.25,0.5,-0.25,0.375),
+    pdfSet   = cms.string("NNPDF30_nlo_as_0118"),
+    cmsE     = era_dependent_settings.cmsE #center of mass energy in GeV
+  )
+  process.globalTablesMCTask.add(process.tauSpinnerWeightTable)
+
+  return process
+
 def customize(process):
   #customize printout frequency
   maxEvts = process.maxEvents.input.value()
@@ -94,4 +115,7 @@ def customize(process):
   process = addTrackVarsToTimeLifeInfo(process)
 
   process = customizePV(process)
+
+  process = addSpinnerWeights(process)
+
   return process


### PR DESCRIPTION
As title of this PR says: it adds a producer and configuration to produce a table with TauSpinner weights for HTT samples. 
The weights (10 numbers / event) are produced only for samples with gen H boson (pdgId=25) with two tau daughters. It was verified that nothing is produced for TTbar and data samples as expected. 

The only issue can be with HH samples with at least one of the Higges (1st in the event history) decaying to taus: in such a case weights will be produced, but will be meaningless. In HH samples with only one H decaying to taus, i.e. HH->(tau,tau)(XX)/(XX)(tau,tau), the weights will be present in events when 1st Higgs decays to taus, but not when the second. However, it can be not a big problem as in such samples the weights are not expected to be used. This behavior was not explicitly tested (can be done), but it is expected basing on code structure.