### PR TITLE
Add covariance of IP vectors of e, mu and tau

### DIFF
--- a/NanoProd/python/customize.py
+++ b/NanoProd/python/customize.py
@@ -99,6 +99,49 @@ def addSpinnerWeights(process):
 
   return process
 
+def addIPCovToLeptons(process,lepton='all'):
+  numToXYZ = {0:'x',1:'y',2:'z'}
+  if (lepton == 'e' or lepton == 'all') and hasattr(process,'electronTimeLifeInfoTable'):
+    tag = cms.InputTag('electronTimeLifeInfos')
+    varPSet = process.electronTimeLifeInfoTable.externalTypedVariables
+    for i in range(0,3):
+      for j in range(i,3):
+        setattr(varPSet,'IP_cov'+str(j)+str(i),cms.PSet(
+          doc = cms.string('IP covariance element ('+str(j)+','+str(i)+')'),
+          expr = cms.string('ipCovariance.c'+numToXYZ[j]+numToXYZ[i]+'()'),
+          lazyEval = cms.untracked.bool(False),
+          precision = cms.int32(10),
+          src = tag,
+          type = cms.string('float')
+        ))
+  if (lepton == 'mu' or lepton == 'all') and hasattr(process,'muonTimeLifeInfoTable'):
+    tag = cms.InputTag('muonTimeLifeInfos')
+    varPSet = process.muonTimeLifeInfoTable.externalTypedVariables
+    for i in range(0,3):
+      for j in range(i,3):
+        setattr(varPSet,'IP_cov'+str(j)+str(i),cms.PSet(
+          doc = cms.string('IP covariance element ('+str(j)+','+str(i)+')'),
+          expr = cms.string('ipCovariance.c'+numToXYZ[j]+numToXYZ[i]+'()'),
+          lazyEval = cms.untracked.bool(False),
+          precision = cms.int32(10),
+          src = tag,
+          type = cms.string('float')
+        ))
+  if (lepton == 'tau' or lepton == 'all') and hasattr(process,'tauTimeLifeInfoTable'):
+    tag = cms.InputTag('tauTimeLifeInfos')
+    varPSet = process.tauTimeLifeInfoTable.externalTypedVariables
+    for i in range(0,3):
+      for j in range(i,3):
+        setattr(varPSet,'IP_cov'+str(j)+str(i),cms.PSet(
+          doc = cms.string('IP covariance element ('+str(j)+','+str(i)+')'),
+          expr = cms.string('ipCovariance.c'+numToXYZ[j]+numToXYZ[i]+'()'),
+          lazyEval = cms.untracked.bool(False),
+          precision = cms.int32(10),
+          src = tag,
+          type = cms.string('float')
+        ))
+
+  return process
 
 def customize(process):
   #customize printout frequency
@@ -113,6 +156,7 @@ def customize(process):
 
   from PhysicsTools.NanoAOD.leptonTimeLifeInfo_common_cff import addTrackVarsToTimeLifeInfo
   process = addTrackVarsToTimeLifeInfo(process)
+  process = addIPCovToLeptons(process)
 
   process = customizePV(process)
 

--- a/NanoProd/python/customize.py
+++ b/NanoProd/python/customize.py
@@ -100,47 +100,22 @@ def addSpinnerWeights(process):
   return process
 
 def addIPCovToLeptons(process,lepton='all'):
-  numToXYZ = {0:'x',1:'y',2:'z'}
-  if (lepton == 'e' or lepton == 'all') and hasattr(process,'electronTimeLifeInfoTable'):
-    tag = cms.InputTag('electronTimeLifeInfos')
-    varPSet = process.electronTimeLifeInfoTable.externalTypedVariables
-    for i in range(0,3):
-      for j in range(i,3):
-        setattr(varPSet,'IP_cov'+str(j)+str(i),cms.PSet(
-          doc = cms.string('IP covariance element ('+str(j)+','+str(i)+')'),
-          expr = cms.string('ipCovariance.c'+numToXYZ[j]+numToXYZ[i]+'()'),
-          lazyEval = cms.untracked.bool(False),
-          precision = cms.int32(10),
-          src = tag,
-          type = cms.string('float')
-        ))
-  if (lepton == 'mu' or lepton == 'all') and hasattr(process,'muonTimeLifeInfoTable'):
-    tag = cms.InputTag('muonTimeLifeInfos')
-    varPSet = process.muonTimeLifeInfoTable.externalTypedVariables
-    for i in range(0,3):
-      for j in range(i,3):
-        setattr(varPSet,'IP_cov'+str(j)+str(i),cms.PSet(
-          doc = cms.string('IP covariance element ('+str(j)+','+str(i)+')'),
-          expr = cms.string('ipCovariance.c'+numToXYZ[j]+numToXYZ[i]+'()'),
-          lazyEval = cms.untracked.bool(False),
-          precision = cms.int32(10),
-          src = tag,
-          type = cms.string('float')
-        ))
-  if (lepton == 'tau' or lepton == 'all') and hasattr(process,'tauTimeLifeInfoTable'):
-    tag = cms.InputTag('tauTimeLifeInfos')
-    varPSet = process.tauTimeLifeInfoTable.externalTypedVariables
-    for i in range(0,3):
-      for j in range(i,3):
-        setattr(varPSet,'IP_cov'+str(j)+str(i),cms.PSet(
-          doc = cms.string('IP covariance element ('+str(j)+','+str(i)+')'),
-          expr = cms.string('ipCovariance.c'+numToXYZ[j]+numToXYZ[i]+'()'),
-          lazyEval = cms.untracked.bool(False),
-          precision = cms.int32(10),
-          src = tag,
-          type = cms.string('float')
-        ))
-
+  xyz = [ 'x', 'y', 'z' ]
+  inputs = [ ('e', 'electron'), ('mu', 'muon'), ('tau', 'tau') ]
+  for input_obj, input_col in inputs:
+    if (lepton == input_obj or lepton == 'all') and hasattr(process, f'{input_col}TimeLifeInfoTable'):
+      tag = cms.InputTag(f'{input_col}TimeLifeInfos')
+      varPSet = getattr(process, f'{input_col}TimeLifeInfoTable').externalTypedVariables
+      for i in range(len(xyz)):
+        for j in range(i, len(xyz)):
+            setattr(varPSet, f'IP_cov{j}{i}', cms.PSet(
+              doc = cms.string(f'IP covariance element ({j}, {i})'),
+              expr = cms.string(f'ipCovariance.c{xyz[j]}{xyz[i]}()'),
+              lazyEval = cms.untracked.bool(False),
+              precision = cms.int32(10),
+              src = tag,
+              type = cms.string('float')
+            ))
   return process
 
 def customize(process):


### PR DESCRIPTION
This PR adds (elements of) covariance matrices of IP vectors of e, mu and tau via a new function called by the main customisation function. 
The covariance matrices are read from already produced TimeLifeInfo products and stored in tables of leptons in a similar way and IP vectors.  