### PR TITLE
Fix crash in case of nonexistent UTag-based tauIDs

### DIFF
--- a/NanoProd/python/customize.py
+++ b/NanoProd/python/customize.py
@@ -48,12 +48,12 @@ def customizeTaus(process):
   deepTauCut = "(tauID('decayModeFindingNewDMs') > 0.5 && (" + " || ".join(deepTauCuts) + "))"
   cuts = []
   for vs, score in [ ("jet", 0.05) ]: # [ ("e", 0.05), ("mu", 0.05), ("jet", 0.05) ]:
-    cuts.append(f"tauID('byUTagCHSVS{vs}raw') > {score}")
+    cuts.append(f"(?isTauIDAvailable('byUTagCHSVS{vs}raw')?tauID('byUTagCHSVS{vs}raw'):-1) > {score}")
   utagCHSCut = "(" + " && ".join(cuts) + ")"
 
   cuts = []
   for vs, score in [ ("jet", 0.05) ]: # [ ("e", 0.05), ("mu", 0.05), ("jet", 0.05) ]:
-    cuts.append(f"tauID('byUTagPUPPIVS{vs}raw') > {score}")
+    cuts.append(f"(?isTauIDAvailable('byUTagPUPPIVS{vs}raw')?tauID('byUTagPUPPIVS{vs}raw'):-1) > {score}")
   utagPUPPICut = "(" + " && ".join(cuts) + ")"
 
   process.finalTaus.cut = f"pt > 18 && ( {deepTauCut} || {utagCHSCut} || {utagPUPPICut} )"


### PR DESCRIPTION
As title says: it fixes issue with crashing production of samples on top of run-2 UL, and run-3 122X and 124X samples for which UTag-based tauIDs do not exist. Precisely it refers to UParT on top of PUPPI jet taggers which are not produced for mentioned samples as jet reclustering with relevant puppi tune was not propagated for these samples.