### PR TITLE
Add DeepTauID to boosted taus

### DIFF
--- a/NanoProd/config/skim_htt.yaml
+++ b/NanoProd/config/skim_htt.yaml
@@ -41,7 +41,20 @@ skim:
     - drop Tau_puCorr
     - drop Tau_chargedIso
     - drop Tau_neutralIso
-    - drop ^(n|)boostedTau(_.*|)$
+    - drop boostedTau_chargedIso
+    - drop boostedTau_neutralIso
+    - drop boostedTau_photonsOutsideSignalCone
+    - drop boostedTau_puCorr
+    - drop boostedTau_rawIsodR03
+    - drop boostedTau_idAntiEle2018
+    - drop boostedTau_rawAntiEle2018
+    - drop boostedTau_rawAntiEleCat2018
+    - drop boostedTau_idMVAnewDM2017v2
+    - drop boostedTau_idMVAoldDM2017v2
+    - drop boostedTau_idMVAoldDMdR032017v2
+    - drop boostedTau_rawMVAnewDM2017v2
+    - drop boostedTau_rawMVAoldDM2017v2
+    - drop boostedTau_rawMVAoldDMdR032017v2
     - drop ^(n|)OtherPV(_.*|)$
     - drop ^(n|)Photon(_.*|)$
     - drop ^(n|)LowPtElectron(_.*|)$
@@ -97,6 +110,12 @@ selection: "
   auto fatJet_sel = FatJet_particleNet_XteVsQCD > 0.05 || FatJet_particleNet_XtmVsQCD > 0.05 || FatJet_particleNet_XttVsQCD > 0.05;
   int n_fatJet = FatJet_pt[fatJet_sel].size();
   if(n_fatJet >= 1 || nFatJet >= 2) return true;
+
+  auto boostedtau_base_sel = boostedTau_pt > 18 && abs(boostedTau_eta) < 2.5;
+  auto boostedtau_deepTau_sel = boostedTau_rawBoostedDeepTauRunIIv2p0VSjet > 0.72 && boostedTau_rawBoostedDeepTauRunIIv2p0VSe > 0.1 && boostedTau_rawBoostedDeepTauRunIIv2p0VSmu > 0.003;
+  auto boostedtau_sel = boostedtau_base_sel && boostedtau_deepTau_sel;
+  int n_boostedtaus = boostedTau_pt[boostedtau_sel].size();
+  if(n_boostedtaus >=2 || (n_boostedtaus >=1 && (n_electrons + n_muons)>=1) ) return true; //MB: It will be better to check pairs with 0.1<dR<0.8
 
   if(n_electrons + n_muons < 1) return false;
   float lep_pt = n_electrons > 0 ? Electron_pt[ele_sel][0] : Muon_pt[muon_sel][0];

--- a/NanoProd/config/skim_htt.yaml
+++ b/NanoProd/config/skim_htt.yaml
@@ -118,49 +118,31 @@ selection: "
   int n_boosted_pairs = 0;
   float maxR2 = 0.8*0.8;
   float minR2 = 0.1*0.1;
-  auto eta_sel_tau = boostedTau_eta[boostedtau_sel];
-  auto phi_sel_tau = boostedTau_phi[boostedtau_sel];
-  if(n_boostedtaus >= 2) {
-    for(size_t i=0; i<n_boostedtaus-1; i++) {
-      for(size_t j=i+1; j<n_boostedtaus; j++) {
-        float deta = eta_sel_tau[i]-eta_sel_tau[j];
-        float dphi = phi_sel_tau[i]-phi_sel_tau[j];
-        while(dphi >= 2.*M_PI) dphi -= 2.*M_PI;
-        while(dphi < 0) dphi += 2.*M_PI;
-        float dr2 = deta*deta + dphi*dphi;
-        if(dr2>minR2 && dr2<maxR2) n_boosted_pairs += 1;
-      }
+auto has_boosted_pair = [&](const RVecF& eta1, const RVecF& phi1, const RVecF& eta2, const RVecF& phi2,
+                            bool is_same) {
+  const size_t i_max = is_same ? eta1.size() - 1 : eta1.size();
+  for(size_t i = 0; i < i_max; ++i) {
+    size_t j = is_same ? i + 1 : 0;
+    for(; j < eta2.size(); ++j) {
+      float deta = eta1[i]-eta2[j];
+      float dphi = TVector2::Phi_mpi_pi(phi1[i]-phi2[j]);
+      float dr2 = deta*deta + dphi*dphi;
+      if( dr2 > minR2 && dr2 < maxR2)
+        return true;
     }
   }
-  if(n_boosted_pairs == 0 && n_boostedtaus >= 1 && n_muons >= 1) {
-    auto eta_sel_mu = Muon_eta[muon_sel];
-    auto phi_sel_mu = Muon_phi[muon_sel];
-    for(size_t i=0; i<n_muons; i++) {
-      for(size_t j=0; j<n_boostedtaus; j++) {
-        float deta = eta_sel_mu[i]-eta_sel_tau[j];
-        float dphi = phi_sel_mu[i]-phi_sel_tau[j];
-        while(dphi >= 2.*M_PI) dphi -= 2.*M_PI;
-        while(dphi < 0) dphi += 2.*M_PI;
-        float dr2 = deta*deta + dphi*dphi;
-        if(dr2>minR2 && dr2<maxR2) n_boosted_pairs += 1;
-      }
-    }
-  }
-  if(n_boosted_pairs == 0 && n_boostedtaus >= 1 && n_electrons >= 1) {
-    auto eta_sel_e = Electron_eta[ele_sel];
-    auto phi_sel_e = Electron_phi[ele_sel];
-    for(size_t i=0; i<n_electrons; i++) {
-      for(size_t j=0; j<n_boostedtaus; j++) {
-        float deta = eta_sel_e[i]-eta_sel_tau[j];
-        float dphi = phi_sel_e[i]-phi_sel_tau[j];
-        while(dphi >= 2.*M_PI) dphi -= 2.*M_PI;
-        while(dphi < 0) dphi += 2.*M_PI;
-        float dr2 = deta*deta + dphi*dphi;
-        if(dr2>minR2 && dr2<maxR2) n_boosted_pairs += 1;
-      }
-    }
-  }
-  if(n_boosted_pairs >=1) return true;
+  return false;
+};
+
+if(n_boostedtaus >= 2 && has_boosted_pair(boostedTau_eta[boostedtau_sel], boostedTau_phi[boostedtau_sel],
+                                          boostedTau_eta[boostedtau_sel], boostedTau_phi[boostedtau_sel], true))
+  return true;
+if(n_boostedtaus >= 1 && has_boosted_pair(boostedTau_eta[boostedtau_sel], boostedTau_phi[boostedtau_sel],
+                                          Muon_eta[boostedtau_sel], Muon_phi[boostedtau_sel], false))
+  return true;
+if(n_boostedtaus >= 1 && has_boosted_pair(boostedTau_eta[boostedtau_sel], boostedTau_phi[boostedtau_sel],
+                                          Electron_eta[boostedtau_sel], Electron_phi[boostedtau_sel], false))
+  return true;
 
   if(n_electrons + n_muons < 1) return false;
   float lep_pt = n_electrons > 0 ? Electron_pt[ele_sel][0] : Muon_pt[muon_sel][0];

--- a/NanoProd/config/skim_htt.yaml
+++ b/NanoProd/config/skim_htt.yaml
@@ -117,7 +117,7 @@ selection: "
   int n_boostedtaus = boostedTau_pt[boostedtau_sel].size();
   int n_boosted_pairs = 0;
   float maxR2 = 0.8*0.8;
-  float minR2 = 0.1*0.1;
+  float minR2 = 0.01*0.01;
 auto has_boosted_pair = [&](const RVecF& eta1, const RVecF& phi1, const RVecF& eta2, const RVecF& phi2,
                             bool is_same) {
   const size_t i_max = is_same ? eta1.size() - 1 : eta1.size();

--- a/NanoProd/config/skim_htt.yaml
+++ b/NanoProd/config/skim_htt.yaml
@@ -115,7 +115,52 @@ selection: "
   auto boostedtau_deepTau_sel = boostedTau_rawBoostedDeepTauRunIIv2p0VSjet > 0.72 && boostedTau_rawBoostedDeepTauRunIIv2p0VSe > 0.1 && boostedTau_rawBoostedDeepTauRunIIv2p0VSmu > 0.003;
   auto boostedtau_sel = boostedtau_base_sel && boostedtau_deepTau_sel;
   int n_boostedtaus = boostedTau_pt[boostedtau_sel].size();
-  if(n_boostedtaus >=2 || (n_boostedtaus >=1 && (n_electrons + n_muons)>=1) ) return true; //MB: It will be better to check pairs with 0.1<dR<0.8
+  int n_boosted_pairs = 0;
+  float maxR2 = 0.8*0.8;
+  float minR2 = 0.1*0.1;
+  auto eta_sel_tau = boostedTau_eta[boostedtau_sel];
+  auto phi_sel_tau = boostedTau_phi[boostedtau_sel];
+  if(n_boostedtaus >= 2) {
+    for(size_t i=0; i<n_boostedtaus-1; i++) {
+      for(size_t j=i+1; j<n_boostedtaus; j++) {
+        float deta = eta_sel_tau[i]-eta_sel_tau[j];
+        float dphi = phi_sel_tau[i]-phi_sel_tau[j];
+        while(dphi >= 2.*M_PI) dphi -= 2.*M_PI;
+        while(dphi < 0) dphi += 2.*M_PI;
+        float dr2 = deta*deta + dphi*dphi;
+        if(dr2>minR2 && dr2<maxR2) n_boosted_pairs += 1;
+      }
+    }
+  }
+  if(n_boosted_pairs == 0 && n_boostedtaus >= 1 && n_muons >= 1) {
+    auto eta_sel_mu = Muon_eta[muon_sel];
+    auto phi_sel_mu = Muon_phi[muon_sel];
+    for(size_t i=0; i<n_muons; i++) {
+      for(size_t j=0; j<n_boostedtaus; j++) {
+        float deta = eta_sel_mu[i]-eta_sel_tau[j];
+        float dphi = phi_sel_mu[i]-phi_sel_tau[j];
+        while(dphi >= 2.*M_PI) dphi -= 2.*M_PI;
+        while(dphi < 0) dphi += 2.*M_PI;
+        float dr2 = deta*deta + dphi*dphi;
+        if(dr2>minR2 && dr2<maxR2) n_boosted_pairs += 1;
+      }
+    }
+  }
+  if(n_boosted_pairs == 0 && n_boostedtaus >= 1 && n_electrons >= 1) {
+    auto eta_sel_e = Electron_eta[ele_sel];
+    auto phi_sel_e = Electron_phi[ele_sel];
+    for(size_t i=0; i<n_electrons; i++) {
+      for(size_t j=0; j<n_boostedtaus; j++) {
+        float deta = eta_sel_e[i]-eta_sel_tau[j];
+        float dphi = phi_sel_e[i]-phi_sel_tau[j];
+        while(dphi >= 2.*M_PI) dphi -= 2.*M_PI;
+        while(dphi < 0) dphi += 2.*M_PI;
+        float dr2 = deta*deta + dphi*dphi;
+        if(dr2>minR2 && dr2<maxR2) n_boosted_pairs += 1;
+      }
+    }
+  }
+  if(n_boosted_pairs >=1) return true;
 
   if(n_electrons + n_muons < 1) return false;
   float lep_pt = n_electrons > 0 ? Electron_pt[ele_sel][0] : Muon_pt[muon_sel][0];

--- a/NanoProd/python/customize.py
+++ b/NanoProd/python/customize.py
@@ -48,12 +48,12 @@ def customizeTaus(process):
   deepTauCut = "(tauID('decayModeFindingNewDMs') > 0.5 && (" + " || ".join(deepTauCuts) + "))"
   cuts = []
   for vs, score in [ ("jet", 0.05) ]: # [ ("e", 0.05), ("mu", 0.05), ("jet", 0.05) ]:
-    cuts.append(f"tauID('byUTagCHSVS{vs}raw') > {score}")
+    cuts.append(f"(?isTauIDAvailable('byUTagCHSVS{vs}raw')?tauID('byUTagCHSVS{vs}raw'):-1) > {score}")
   utagCHSCut = "(" + " && ".join(cuts) + ")"
 
   cuts = []
   for vs, score in [ ("jet", 0.05) ]: # [ ("e", 0.05), ("mu", 0.05), ("jet", 0.05) ]:
-    cuts.append(f"tauID('byUTagPUPPIVS{vs}raw') > {score}")
+    cuts.append(f"(?isTauIDAvailable('byUTagPUPPIVS{vs}raw')?tauID('byUTagPUPPIVS{vs}raw'):-1) > {score}")
   utagPUPPICut = "(" + " && ".join(cuts) + ")"
 
   process.finalTaus.cut = f"pt > 18 && ( {deepTauCut} || {utagCHSCut} || {utagPUPPICut} )"

--- a/NanoProd/python/customize.py
+++ b/NanoProd/python/customize.py
@@ -73,6 +73,16 @@ def customizeTaus(process):
 
   return process
 
+def customizeBoostedTaus(process):
+  cuts = []
+  for vs, score in [ ("jet", 0.72), ("e", 0.05), ("mu", 0.001) ]:
+    cuts.append(f"tauID('byBoostedDeepTau20161718v2p0VS{vs}raw') > {score}")
+  deepTauCut = "(" + " && ".join(cuts) + ")"
+
+  process.finalBoostedTaus.cut = f"pt > 18 && tauID(\'decayModeFindingNewDMs\') && ( {deepTauCut} )"
+
+  return process
+
 def customizePV(process):
   from PhysicsTools.NanoAOD.leptonTimeLifeInfo_common_cff import addExtendVertexInfo
   addExtendVertexInfo(process)
@@ -110,6 +120,7 @@ def customize(process):
   #customize stored objects
   process = customizeGenParticles(process)
   process = customizeTaus(process)
+  process = customizeBoostedTaus(process)
 
   from PhysicsTools.NanoAOD.leptonTimeLifeInfo_common_cff import addTrackVarsToTimeLifeInfo
   process = addTrackVarsToTimeLifeInfo(process)

--- a/env.sh
+++ b/env.sh
@@ -43,6 +43,7 @@ do_install_cmssw() {
     run_cmd scramv1 project CMSSW $CMSSW_VER
     run_cmd cd $CMSSW_VER/src
     run_cmd eval `scramv1 runtime -sh`
+    run_cmd install_cmssw_addons $CMSSW_VER
     run_cmd mkdir NanoProd
     run_cmd ln -s "$this_dir/NanoProd" NanoProd/NanoProd
     run_cmd scram b -j8
@@ -71,6 +72,17 @@ install_cmssw() {
   fi
   if ! [ -f "$this_dir/soft/$CMSSW_VER/.installed" ]; then
     run_cmd $env_cmd $env_cmd_args /usr/bin/env -i HOME=$HOME bash "$this_file" install_cmssw $scram_arch $cmssw_version
+  fi
+}
+
+install_cmssw_addons() {
+  #install CMSSW updates not in official releases
+  #TODO: Consider to add more sophisticated version matching
+  local CMSSW_VER=$1
+  if [ "X$CMSSW_VER" = "XCMSSW_14_0_6_patch1" ]; then
+      run_cmd echo "installing addons for "$CMSSW_VER
+      run_cmd git cms-merge-topic -u cms-tau-pog:CMSSW_14_0_X_tau-pog_BoostedDeepTau
+      run_cmd wget https://github.com/cms-tau-pog/RecoTauTag-TrainingFiles/raw/refs/heads/BoostedDeepTau_v2/BoostedDeepTauId/boosteddeepTau_RunIIv2p0_{core,inner,outer}.pb -P RecoTauTag/TrainingFiles/data/BoostedDeepTauId/
   fi
 }
 

--- a/env.sh
+++ b/env.sh
@@ -43,7 +43,17 @@ do_install_cmssw() {
     run_cmd scramv1 project CMSSW $CMSSW_VER
     run_cmd cd $CMSSW_VER/src
     run_cmd eval `scramv1 runtime -sh`
-    run_cmd install_cmssw_addons $CMSSW_VER
+
+    #install CMSSW updates not in official releases
+    local master_ver=`echo $CMSSW_VER | cut -d'_' -f 2`
+    local sub_ver=`echo $CMSSW_VER | cut -d'_' -f 3`
+    local subsub_ver=`echo $CMSSW_VER | cut -d'_' -f 4`
+    if [[ $master_ver == "14"  && $sub_ver == "0" ]]; then
+      run_cmd echo "=> Installing addons for CMSSW_"${master_ver}"_"$sub_ver
+      run_cmd git cms-merge-topic -u cms-tau-pog:CMSSW_14_0_X_tau-pog_BoostedDeepTau
+      run_cmd wget https://github.com/cms-tau-pog/RecoTauTag-TrainingFiles/raw/refs/heads/BoostedDeepTau_v2/BoostedDeepTauId/boosteddeepTau_RunIIv2p0_{core,inner,outer}.pb -P RecoTauTag/TrainingFiles/data/BoostedDeepTauId/
+    fi
+
     run_cmd mkdir NanoProd
     run_cmd ln -s "$this_dir/NanoProd" NanoProd/NanoProd
     run_cmd scram b -j8
@@ -72,17 +82,6 @@ install_cmssw() {
   fi
   if ! [ -f "$this_dir/soft/$CMSSW_VER/.installed" ]; then
     run_cmd $env_cmd $env_cmd_args /usr/bin/env -i HOME=$HOME bash "$this_file" install_cmssw $scram_arch $cmssw_version
-  fi
-}
-
-install_cmssw_addons() {
-  #install CMSSW updates not in official releases
-  #TODO: Consider to add more sophisticated version matching
-  local CMSSW_VER=$1
-  if [ "X$CMSSW_VER" = "XCMSSW_14_0_6_patch1" ]; then
-      run_cmd echo "installing addons for "$CMSSW_VER
-      run_cmd git cms-merge-topic -u cms-tau-pog:CMSSW_14_0_X_tau-pog_BoostedDeepTau
-      run_cmd wget https://github.com/cms-tau-pog/RecoTauTag-TrainingFiles/raw/refs/heads/BoostedDeepTau_v2/BoostedDeepTauId/boosteddeepTau_RunIIv2p0_{core,inner,outer}.pb -P RecoTauTag/TrainingFiles/data/BoostedDeepTauId/
   fi
 }
 


### PR DESCRIPTION
This PR adds DeepTauID to boosted taus with an "addon" mechanism, i.e. with merging development branch with relevant changes on top of a plain CMSSW release and uploading model files.

Tested localy with 2022 and 2018 samples (the latter with #41 included). 

**WARNING:** in current setup of HTT skim boostedTau table is removed and boostedTaus are not used to select events, so to profit from the newly added tauID one needs to restore the table (probably with dropping some branches) and modify the event selection.

**Note:** in default setup proposed for nano v15 (run2+run3 legacy) in https://github.com/cms-sw/cmssw/pull/46112 pt threshold to select boosted taus is 25 GeV (lowered from 40 GeV) and it is suplemented by requirement of an logical OR of loosest WP of MVAIso and BoostedDeepTauVSJet > 0.82 (WP with j->tau FR of ~85%).
Cutoff values of >0.73 and >0.90 correspond with j->tau FR of ~80% and ~90%, respectively.