### PR TITLE
Addon to produce raw scores of DeepTau v2.5 w/o domain adaptation

### DIFF
--- a/NanoProd/config/skim_htt.yaml
+++ b/NanoProd/config/skim_htt.yaml
@@ -71,8 +71,9 @@ selection: "
   auto tau_base_sel = Tau_pt > 18 && abs(Tau_eta) < 2.5;
   auto tau_deepTau_v2p1_sel = Tau_rawDeepTau2017v2p1VSmu > 0.05 && Tau_idDeepTau2017v2p1VSjet > 0 && Tau_idDeepTau2017v2p1VSe > 0;
   auto tau_deepTau_v2p5_sel = Tau_rawDeepTau2018v2p5VSmu > 0.05 && Tau_idDeepTau2018v2p5VSjet > 0 && Tau_idDeepTau2018v2p5VSe > 0;
+  auto tau_deepTau_v2p5noDA_sel = Tau_rawDeepTau2018v2p5noDAVSmu > 0.05 && Tau_idDeepTau2018v2p5noDAVSjet > 0 && Tau_idDeepTau2018v2p5noDAVSe > 0;
   auto tau_pnet_sel = Tau_rawPNetVSjet > 0.05 && Tau_rawPNetVSe > 0.05 && Tau_rawPNetVSmu > 0.05;
-  auto tau_sel = tau_base_sel && (tau_deepTau_v2p1_sel || tau_deepTau_v2p5_sel || tau_pnet_sel);
+  auto tau_sel = tau_base_sel && (tau_deepTau_v2p1_sel || tau_deepTau_v2p5_sel || tau_deepTau_v2p5noDA_sel || tau_pnet_sel);
 
   int n_electrons = Electron_pt[ele_sel].size();
   int n_muons = Muon_pt[muon_sel].size();

--- a/NanoProd/python/customize.py
+++ b/NanoProd/python/customize.py
@@ -33,7 +33,7 @@ def customizeGenParticles(process):
 
 def customizeTaus(process):
   deepTauCuts = []
-  for deep_tau_ver in [ "2017v2p1", "2018v2p5" ]:
+  for deep_tau_ver in [ "2017v2p1", "2018v2p5", "2018v2p5noDA" ]:
     cuts = []
     e_VVVLoose = WORKING_POINTS_v2p5["e"]["VVVLoose"]
     mu_VVLoose = 0.05

--- a/env.sh
+++ b/env.sh
@@ -53,6 +53,8 @@ do_install_cmssw() {
       run_cmd git cms-merge-topic -u cms-tau-pog:CMSSW_14_0_X_NanoProd_Addon_Powheg
       run_cmd git cms-merge-topic -u cms-tau-pog:CMSSW_14_0_X_tau-pog_BoostedDeepTau
       run_cmd wget https://github.com/cms-tau-pog/RecoTauTag-TrainingFiles/raw/refs/heads/BoostedDeepTau_v2/BoostedDeepTauId/boosteddeepTau_RunIIv2p0_{core,inner,outer}.pb -P RecoTauTag/TrainingFiles/data/BoostedDeepTauId/
+      run_cmd git cms-merge-topic -u cms-tau-pog:CMSSW_14_0_X_tau-pog_DeepTauNoDA
+      run_cmd wget https://github.com/cms-tau-pog/RecoTauTag-TrainingFiles/raw/refs/heads/deepTau_v2p5_noDomainAdaptation/DeepTauId/deepTau_2018v2p5_noDomainAdaptation_{core,inner,outer}.pb -P RecoTauTag/TrainingFiles/data/DeepTauId/
     fi
 
     run_cmd mkdir NanoProd


### PR DESCRIPTION
As title says it adds raw scores of DeepTau v2.5 w/o domain adaptation with private development cmssw branch and model files.

The only (small?) caveat of this addon is lack of WPs for a new set of discriminants which are consequently not used in the event and tau object (pre)selections. However, it is expected to introduce only a small bias as the new discriminants are strongly correlated with regular DeepTau v2.5 (w/ domain adaptation) and the selections are quite loose. Or we want to have at least an approximate set of VVVLoose WPs?